### PR TITLE
Add content padding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.idea/kotlinc.xml
 /.idea/vcs.xml
 /.idea/misc.xml
+/.idea/inspectionProfiles
 .DS_Store
 /build
 /captures

--- a/demo/src/main/kotlin/eu/wewox/minabox/Example.kt
+++ b/demo/src/main/kotlin/eu/wewox/minabox/Example.kt
@@ -14,6 +14,10 @@ enum class Example(
         "Mina Box Simple",
         "Simple Mina Box layout example"
     ),
+    MinaBoxContentPadding(
+        "Mina Box Padding",
+        "Mina Box example with content padding"
+    ),
     MinaBoxAdvanced(
         "Mina Box Advanced",
         "Advanced Mina Box layout example"

--- a/demo/src/main/kotlin/eu/wewox/minabox/MainActivity.kt
+++ b/demo/src/main/kotlin/eu/wewox/minabox/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import eu.wewox.minabox.screens.MinaBoxAdvancedScreen
+import eu.wewox.minabox.screens.MinaBoxContentPaddingScreen
 import eu.wewox.minabox.screens.MinaBoxSimpleScreen
 import eu.wewox.minabox.ui.components.TopBar
 import eu.wewox.minabox.ui.theme.MinaBoxTheme
@@ -58,6 +59,7 @@ class MainActivity : ComponentActivity() {
                     when (selected) {
                         null -> RootScreen(onExampleClick = { example = it })
                         Example.MinaBoxSimple -> MinaBoxSimpleScreen()
+                        Example.MinaBoxContentPadding -> MinaBoxContentPaddingScreen()
                         Example.MinaBoxAdvanced -> MinaBoxAdvancedScreen()
                     }
                 }

--- a/demo/src/main/kotlin/eu/wewox/minabox/screens/MinaBoxContentPaddingScreen.kt
+++ b/demo/src/main/kotlin/eu/wewox/minabox/screens/MinaBoxContentPaddingScreen.kt
@@ -1,0 +1,126 @@
+package eu.wewox.minabox.screens
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import eu.wewox.minabox.Example
+import eu.wewox.minabox.MinaBox
+import eu.wewox.minabox.MinaBoxItem
+import eu.wewox.minabox.ui.components.TopBar
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Mina Box example with content padding.
+ */
+@Composable
+fun MinaBoxContentPaddingScreen() {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = Example.MinaBoxContentPadding.label,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.7f))
+            )
+        }
+    ) { padding ->
+        BoxWithConstraints {
+            val gapPx = LocalDensity.current.run { ItemsGap.roundToPx() }
+            val itemWidth = (constraints.maxWidth - gapPx * 3) / 2f
+            val itemHeight = itemWidth * 2
+
+            MinaBox(
+                contentPadding = PaddingValues(
+                    top = ItemsGap + padding.calculateTopPadding(),
+                    bottom = ItemsGap + padding.calculateBottomPadding(),
+                    start = ItemsGap,
+                    end = ItemsGap,
+                ),
+            ) {
+                items(
+                    count = ItemsCount,
+                    layoutInfo = { createLayoutInfo(it, gapPx, itemWidth, itemHeight) },
+                    itemContent = { ScaleUpItem(index = it) }
+                )
+            }
+        }
+    }
+}
+
+private fun createLayoutInfo(
+    index: Int,
+    gapPx: Int,
+    itemWidth: Float,
+    itemHeight: Float,
+): MinaBoxItem {
+    val x = if (index % 2 != 0) {
+        itemWidth + gapPx
+    } else {
+        0f
+    }
+
+    val y = if (index % 2 != 0) {
+        (index / 2) * (itemHeight + gapPx)
+    } else {
+        ((index / 2 - 1) * (itemHeight + gapPx) + itemHeight / 2f + gapPx).coerceAtLeast(0f)
+    }
+
+    val height = if (index == 0 || index == ItemsCount - 1) {
+        itemHeight / 2f
+    } else {
+        itemHeight
+    }
+
+    return MinaBoxItem(
+        x = x,
+        y = y,
+        width = itemWidth,
+        height = height,
+    )
+}
+
+@Composable
+private fun ScaleUpItem(index: Int, modifier: Modifier = Modifier) {
+    val scale = remember { Animatable(0.75f) }
+    LaunchedEffect(Unit) {
+        delay(100)
+        launch {
+            scale.animateTo(1f)
+        }
+    }
+    Surface(
+        color = MaterialTheme.colorScheme.primary,
+        shape = RoundedCornerShape(16.dp),
+        shadowElevation = 4.dp,
+        modifier = modifier.scale(scale.value)
+    ) {
+        Box(Modifier.fillMaxSize()) {
+            Text(
+                text = "#$index",
+                style = MaterialTheme.typography.displayMedium,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+    }
+}
+
+private val ItemsGap = 16.dp
+private const val ItemsCount = 50

--- a/demo/src/main/kotlin/eu/wewox/minabox/ui/components/TopBar.kt
+++ b/demo/src/main/kotlin/eu/wewox/minabox/ui/components/TopBar.kt
@@ -12,13 +12,14 @@ import eu.wewox.minabox.ui.theme.SpacingMedium
  * The reusable component for top bar.
  *
  * @param title The text to show in top bar.
+ * @param modifier The modifier instance for the root composable.
  */
 @Composable
-fun TopBar(title: String) {
+fun TopBar(title: String, modifier: Modifier = Modifier) {
     Text(
         text = title,
         style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier
+        modifier = modifier
             .padding(SpacingMedium)
             .statusBarsPadding()
     )


### PR DESCRIPTION
* This PR adds a content padding support, so that LazyTable & ProgramGuide could be drawn below system bars
* Addresses https://github.com/oleksandrbalan/lazytable/issues/2

https://github.com/oleksandrbalan/minabox/assets/20944869/89986285-08e7-4f29-bd42-b2ab8a40f67f

