### PR TITLE
Improve MinaBox state remembering

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -16,7 +16,7 @@
             </builds>
           </compositeBuild>
         </compositeConfiguration>
-        <option name="testRunner" value="GRADLE" />
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/demo/src/commonMain/kotlin/eu/wewox/minabox/screens/MinaBoxAdvancedScreen.kt
+++ b/demo/src/commonMain/kotlin/eu/wewox/minabox/screens/MinaBoxAdvancedScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import eu.wewox.minabox.Example
 import eu.wewox.minabox.MinaBox
 import eu.wewox.minabox.MinaBoxItem
-import eu.wewox.minabox.rememberMinaBoxState
+import eu.wewox.minabox.rememberSaveableMinaBoxState
 import eu.wewox.minabox.ui.components.TopBar
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -58,7 +58,7 @@ fun MinaBoxAdvancedScreen(
         }
 
         val scope = rememberCoroutineScope()
-        val state = rememberMinaBoxState()
+        val state = rememberSaveableMinaBoxState()
         MinaBox(
             state = state,
             modifier = Modifier.padding(padding)

--- a/minabox/src/commonMain/kotlin/eu/wewox/minabox/MinaBox.kt
+++ b/minabox/src/commonMain/kotlin/eu/wewox/minabox/MinaBox.kt
@@ -44,7 +44,7 @@ import kotlin.math.min
 @Composable
 public fun MinaBox(
     modifier: Modifier = Modifier,
-    state: MinaBoxState = rememberMinaBoxState(),
+    state: MinaBoxState = rememberSaveableMinaBoxState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     scrollDirection: MinaBoxScrollDirection = MinaBoxScrollDirection.BOTH,
     content: MinaBoxScope.() -> Unit

--- a/minabox/src/commonMain/kotlin/eu/wewox/minabox/MinaBoxPositionProvider.kt
+++ b/minabox/src/commonMain/kotlin/eu/wewox/minabox/MinaBoxPositionProvider.kt
@@ -37,15 +37,15 @@ public interface MinaBoxPositionProvider {
     ): Offset
 
     /**
-     * TODO
+     * Returns offset of the item.
      *
-     * @param itemSize
-     * @param alignment
-     * @param paddingStart
-     * @param paddingTop
-     * @param paddingEnd
-     * @param paddingBottom
-     * @return
+     * @param itemSize The item size (width and height).
+     * @param alignment The alignment to align item inside the [MinaBox].
+     * @param paddingStart An additional start padding to tweak alignment.
+     * @param paddingTop An additional top padding to tweak alignment.
+     * @param paddingEnd An additional end padding to tweak alignment.
+     * @param paddingBottom An additional bottom padding to tweak alignment.
+     * @return An item offset.
      */
     public fun align(
         itemSize: IntSize,


### PR DESCRIPTION
- Replace `rememberMinaBoxState` with `rememberSaveableMinaBoxState` to ensure state persistence across configuration changes and deprecate `rememberMinaBoxState`.
- Update `MinaBox` composable to use `rememberSaveableMinaBoxState` by default.
- Add a `Saver` implementation to the `MinaBoxState` for proper state restoration.
- Improve docs.